### PR TITLE
Allow changing the app bar background

### DIFF
--- a/lib/src/settings_screen.dart
+++ b/lib/src/settings_screen.dart
@@ -52,6 +52,7 @@ class SettingsScreen extends StatelessWidget {
   final String confirmModalTitle;
   final String confirmModalCancelCaption;
   final String confirmModalConfirmCaption;
+  final Color appBarBackgroundColor;
 
   SettingsScreen({
     @required this.title,
@@ -60,6 +61,7 @@ class SettingsScreen extends StatelessWidget {
     this.confirmModalTitle,
     this.confirmModalCancelCaption,
     this.confirmModalConfirmCaption,
+    this.appBarBackgroundColor,
   });
 
   @override
@@ -67,6 +69,7 @@ class SettingsScreen extends StatelessWidget {
     return _ConfirmableScreen(
       child: Scaffold(
         appBar: AppBar(
+          backgroundColor: appBarBackgroundColor,
           title: Text(title),
         ),
         body: ListView.builder(


### PR DESCRIPTION
Allows the user to override the background color for the `AppBar`.

Should the [SettingsContainer](https://github.com/BarthaBRW/shared_preferences_settings/blob/08378f144a9882cc97eed753f00e0119d675bc20/lib/src/settings_screen.dart#L2250) also be updated to allow passing this param? I'm still in the beginning phases of this package.