### PR TITLE
Fix slider calculation for evenly divisible values

### DIFF
--- a/lib/src/settings_screen.dart
+++ b/lib/src/settings_screen.dart
@@ -2380,7 +2380,7 @@ class _SettingsSlider extends StatelessWidget {
             value: value,
             min: min,
             max: max,
-            divisions: (max - min) ~/ (step) + 1,
+            divisions: (max - min) ~/ (step),
             onChanged: enabled ? onChanged : null,
           ),
         ),


### PR DESCRIPTION
When using the slider, I noticed a bug where for evenly divisible values, the slider doesn't step correctly.

Example, for
```
  SliderSettingsTile(
              settingKey: 'my-key',
              title: 'Slider demo',
              defaultValue: 100.0,
              minValue: 0.0,
              maxValue: 100.0,
              step: 10.0,
            ),
```
I get the following result
![Screen Recording 2020-06-19 at 6 13 09 PM](https://user-images.githubusercontent.com/28543909/85183309-405ea780-b259-11ea-9e78-56184af7a77d.gif)

Likely because 100 / 10 + 1 = 11, so the step becomes 100 / 11 = 9.090909...

After the fix, for the same code
![Screen Recording 2020-06-19 at 6 14 27 PM](https://user-images.githubusercontent.com/28543909/85183338-5ff5d000-b259-11ea-86dd-69c4528ee127.gif)

Sorry for the super slow gif, conversion from `mov` wasn't the best.


