### PR TITLE
Attempted fix for RadioPickerSettingsTile: type '(String) => void' is not a subtype of type '(String?) => dynamic' of 'onChanged'

### DIFF
--- a/lib/src/settings_screen.dart
+++ b/lib/src/settings_screen.dart
@@ -1638,13 +1638,13 @@ class __SettingsModalState extends State<_SettingsModal> {
     );
   }
 
-  void _onChanged(String newValue) {
+  void _onChanged(String? newValue) {
     if (widget.refreshStateOnChange!) {
       setState(() {
-        _handleChange(newValue);
+        _handleChange(newValue!);
       });
     } else {
-      _handleChange(newValue);
+      _handleChange(newValue!);
     }
   }
 


### PR DESCRIPTION
Here is an attempted fix for issue #27 

It works with my code and sound nullsafety, but I am not really sure if that is the right approach.