### PR TITLE
Make async functions return Futures

### DIFF
--- a/lib/src/settings.dart
+++ b/lib/src/settings.dart
@@ -169,19 +169,19 @@ class Settings {
     return (await SharedPreferences.getInstance()).getBool(key) ?? defaultValue;
   }
 
-  void pingString(String key, String? defaultValue) async {
+  Future<void> pingString(String key, String? defaultValue) async {
     _stringChanged(key, await getString(key, defaultValue));
   }
 
-  void pingDouble(String key, double defaultValue) async {
+  Future<void> pingDouble(String key, double defaultValue) async {
     _doubleChanged(key, await getDouble(key, defaultValue));
   }
 
-  void pingBool(String key, bool defaultValue) async {
+  Future<void> pingBool(String key, bool defaultValue) async {
     _boolChanged(key, await getBool(key, defaultValue));
   }
 
-  void save(String key, dynamic value) async {
+  Future<void> save(String key, dynamic value) async {
     SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
     if (value is int) {
       await sharedPreferences.setInt(key, value);


### PR DESCRIPTION
If the functions don't return a `Future` then we can't use `await` to ensure that the function has completed.