### PR TITLE
Make bool settings key non-null for consistency

### DIFF
--- a/lib/src/settings.dart
+++ b/lib/src/settings.dart
@@ -52,17 +52,17 @@ class Settings {
   Map<String, _SettingStream<bool>> _boolStreams =
       Map<String, _SettingStream<bool>>();
 
-  _SettingStream? _getBoolStreamOf(String? settingKey) {
+  _SettingStream? _getBoolStreamOf(String settingKey) {
     if (_boolStreams.containsKey(settingKey)) {
       return _boolStreams[settingKey];
     }
     _SettingStream<bool> stream = _SettingStream<bool>();
-    _boolStreams[settingKey!] = stream;
+    _boolStreams[settingKey] = stream;
     return stream;
   }
 
   StreamBuilder<bool> onBoolChanged({
-    required String? settingKey,
+    required String settingKey,
     required bool defaultValue,
     required Function childBuilder,
   }) {

--- a/lib/src/settings.dart
+++ b/lib/src/settings.dart
@@ -109,9 +109,7 @@ class Settings {
   }
 
   void _stringChanged(String settingKey, String? value) {
-    if (_stringStreams.containsKey(settingKey)) {
-      _stringStreams[settingKey]!.push(value);
-    }
+    _stringStreams[settingKey]?.push(value);
   }
 
   //

--- a/lib/src/settings.dart
+++ b/lib/src/settings.dart
@@ -15,8 +15,7 @@ class Settings {
 
   //
 
-  Map<String, _SettingStream<int>> _intStreams =
-      Map<String, _SettingStream<int>>();
+  var _intStreams = Map<String, _SettingStream<int>>();
 
   _SettingStream? _getIntStreamOf(String settingKey) {
     if (_intStreams.containsKey(settingKey)) {
@@ -49,8 +48,7 @@ class Settings {
 
   //
 
-  Map<String, _SettingStream<bool>> _boolStreams =
-      Map<String, _SettingStream<bool>>();
+  var _boolStreams = Map<String, _SettingStream<bool>>();
 
   _SettingStream? _getBoolStreamOf(String settingKey) {
     if (_boolStreams.containsKey(settingKey)) {
@@ -114,8 +112,7 @@ class Settings {
 
   //
 
-  Map<String, _SettingStream<double>> _doubleStreams =
-      Map<String, _SettingStream<double>>();
+  var _doubleStreams = Map<String, _SettingStream<double>>();
 
   _SettingStream? _getDoubleStreamOf(String settingKey) {
     if (_doubleStreams.containsKey(settingKey)) {

--- a/lib/src/settings.dart
+++ b/lib/src/settings.dart
@@ -83,8 +83,7 @@ class Settings {
 
   //
 
-  Map<String, _SettingStream<String>> _stringStreams =
-      Map<String, _SettingStream<String>>();
+  var _stringStreams = Map<String, _SettingStream<String?>>();
 
   _SettingStream? _getStringStreamOf(String settingKey) {
     if (_stringStreams.containsKey(settingKey)) {
@@ -109,7 +108,7 @@ class Settings {
     );
   }
 
-  void _stringChanged(String settingKey, String value) {
+  void _stringChanged(String settingKey, String? value) {
     if (_stringStreams.containsKey(settingKey)) {
       _stringStreams[settingKey]!.push(value);
     }
@@ -155,9 +154,9 @@ class Settings {
     return (await SharedPreferences.getInstance()).getInt(key) ?? defaultValue;
   }
 
-  Future<String> getString(String key, String? defaultValue) async {
+  Future<String?> getString(String key, String? defaultValue) async {
     return (await SharedPreferences.getInstance()).getString(key) ??
-        defaultValue!;
+        defaultValue;
   }
 
   Future<double> getDouble(String key, double defaultValue) async {


### PR DESCRIPTION
All the other setting keys are non-null, so it breaks a generic wrapper I've written